### PR TITLE
updated Erd to add orders

### DIFF
--- a/diagrams/erd.dbml
+++ b/diagrams/erd.dbml
@@ -4,31 +4,53 @@ Table Governors {
   isActive boolean
   colonyId int
 }
+
 Table Colonies {
   id int pk
   name varchar
 }
+
 Table Facilities {
   id int pk
   name varchar
   isActive boolean
 }
+
 Table Minerals {
   id int pk
   mineral varchar
 }
+
 Table Facility_Minerals {
   mineralId int
   facilityId int
   quantity int
 }
+
 Table Colony_Minerals {
   mineralId int
   colonyId int
   quantity int
 }
+
+Table Orders {
+  id int pk
+  governorId int
+  colonyId int
+}
+
+Table Order_Details {
+  orderId fk
+  mineralId fk
+  quantity int
+}
+
 Ref: "Minerals"."id" < "Facility_Minerals"."mineralId"
 Ref: "Minerals"."id" < "Colony_Minerals"."mineralId"
 Ref: "Colonies"."id" < "Colony_Minerals"."colonyId"
 Ref: "Facilities"."id" < "Facility_Minerals"."facilityId"
 Ref: "Colonies"."id" < "Governors"."colonyId"
+Ref: "Orders"."governorId" < "Governors"."id"
+Ref: "Orders"."colonyId" < "Colonies"."id"
+Ref: "Order_Details"."orderId" < "Orders"."id"
+Ref: "Order_Details"."mineralId" < "Minerals"."id"


### PR DESCRIPTION
## What?
Add Orders table to the ERD.

## Why?
To model and manage orders placed by governors for colonies in the system.

## How?
- Created Orders table with columns: id (primary key), governorId (foreign key to Governors.id), colonyId (foreign key to Colonies.id).
- Added foreign key constraints to maintain data integrity.
- Updated ERD diagram to include Orders table and its relationships.
