### PR TITLE
space cart is now updating when user selects a mineral

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -4,6 +4,7 @@
 // create facilitiesHTML variable that contains a dropdown that allows the user to select a facility. Use the <select> tag.
 
 // Fetch the facilities data from the database
+import { setFacility } from './TransientState.js';
 export const fetchFacilities = async () => {
   let response = await fetch('http://localhost:8088/facilities');
   let facilities = await response.json();

--- a/scripts/FacilityMinerals.js
+++ b/scripts/FacilityMinerals.js
@@ -1,3 +1,6 @@
+import { SpaceCart } from './SpaceCart.js';
+import { setFacility, setMineral } from './TransientState.js';
+
 // Fetch minerals associated with a specific facility ID
 export const fetchFacilityMinerals = async (facilityId) => {
   let response = await fetch(
@@ -36,16 +39,30 @@ export const fetchFacilityMinerals = async (facilityId) => {
   return combinedMinerals;
 };
 
+const handleMineralChoice = async (event) => {
+  if (event.target.name === 'facilityMineral') {
+    setMineral({
+      id: parseInt(event.target.value),
+      checked: event.target.checked,
+      facilityName: event.target.dataset.facility,
+    });
+  }
+  const spaceCartEl = document.querySelector('.order');
+  const spaceCart = await SpaceCart();
+  spaceCartEl.innerHTML = spaceCart;
+};
+
 // Function to render facility minerals as HTML
 export const renderFacilityMineralsHTML = (facilityName, minerals) => {
   // Create the heading
+  document.addEventListener('change', handleMineralChoice);
   let mineralsHTML = `<h3>Facility Minerals for ${facilityName}</h3><div>`;
 
   // Loop through each mineral and add it to the HTML
   for (let i = 0; i < minerals.length; i++) {
     let mineral = minerals[i];
     mineralsHTML += `
-            <input type="radio" id="mineral_${mineral.mineralId}" name="facilityMineral" value="${mineral.mineralId}">
+            <input data-facility="${facilityName}" type="radio" id="mineral_${mineral.mineralId}" name="facilityMineral" value="${mineral.mineralId}">
             <label for="mineral_${mineral.mineralId}">${mineral.quantity} tons of ${mineral.name}</label><br>`;
   }
 
@@ -66,7 +83,7 @@ export const handleFacilityDropdownChange = (facilities) => {
     // Get the selected facility ID
     let facilityId = parseInt(event.target.value);
     let facilityName = '';
-
+    setFacility(facilityId);
     // Find the facility name that matches the selected ID
     for (let i = 0; i < facilities.length; i++) {
       if (facilities[i].id === facilityId) {

--- a/scripts/SpaceCart.js
+++ b/scripts/SpaceCart.js
@@ -1,3 +1,17 @@
-export const SpaceCart = () => {
-  return '<button id="placeOrder">Place Order</button>';
+import { transientState } from './TransientState.js';
+
+export const SpaceCart = async () => {
+  const response = await fetch('http://localhost:8088/minerals');
+  const minerals = await response.json();
+  const selectedMineral = transientState.mineralObj;
+  let html = `<h2>Space Cart</h2>`;
+  if (selectedMineral.checked) {
+    for (const mineral of minerals) {
+      if (mineral.id === selectedMineral.id) {
+        html += `<p>1 ton of ${mineral.mineral} from ${selectedMineral.facilityName}</p>
+        <button id="placeOrder">Place Order</button>`;
+      }
+    }
+  }
+  return html;
 };

--- a/scripts/TransientState.js
+++ b/scripts/TransientState.js
@@ -1,20 +1,27 @@
 export const transientState = {
   governorId: 0,
   colonyId: 0,
+  mineralObj: {},
+  selectedFacility: 0,
 };
 
 export const setGovernor = (chosenGovernor) => {
   transientState.governorId = chosenGovernor;
+  console.log(transientState);
 };
 export const setColony = (chosenColony) => {
   transientState.colonyId = chosenColony;
   console.log(transientState);
 };
+export const setMineral = (chosenMineral) => {
+  transientState.mineralObj = chosenMineral;
+  console.log(transientState);
+};
 
-// export const setFacility = (facilityId) => {
-//     state.selectedFacility = facilityId
-//     document.dispatchEvent(new CustomEvent("stateChanged"))
-// }
+export const setFacility = (facilityId) => {
+  transientState.selectedFacility = facilityId;
+  console.log(transientState);
+};
 
 // export const purchaseMineral = () => {
 //     /*

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -9,7 +9,7 @@ const render = async () => {
   const colonies = await Colonies();
   const facilities = await fetchFacilities();
   const facilitiesDropdownHTML = renderFacilitiesDropdown(facilities);
-  const spaceCart = SpaceCart();
+  const spaceCart = await SpaceCart();
 
   const container = document.getElementById('container');
 
@@ -40,8 +40,9 @@ const render = async () => {
                 </section>
             </article>
              <article class="order">
-      <h2>Space Cart</h2>
+      
     ${spaceCart}
+    <button id="placeOrder">Place Order</button>
         </article>
         </div>`;
 


### PR DESCRIPTION
# Description
I added a mineralObj to transientState, which starts out as an empty object, but the keys "id, checked, and facilityName" are added to it when the user selects a mineral. The space cart then takes that information from the state and then fetches all minerals, to see if the mineral clicked on matches on in the database. If it does, the html of the space cart is updated to show 1 ton of whichever metal the user clicked, and also which facility it came from. 


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1: Pull the develop branch
- [ ] Step 2: Select a governor, facility, and mineral. The page should display different options based on what is clicked on.
- [ ] Step 3: These selections are all being saved to state, which can be seen by opening the console. 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no errors
