### PR TITLE
facility minerals rerenders when user places an order

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -73,30 +73,1561 @@
   ],
   "facilityMinerals": [
     {
+      "id": 1,
       "mineralId": 2,
       "facilityId": 3,
       "quantity": 20
     },
     {
+      "id": 2,
       "mineralId": 1,
       "facilityId": 3,
       "quantity": 2
     },
     {
+      "id": 3,
       "mineralId": 1,
       "facilityId": 1,
-      "quantity": 18
+      "quantity": 13
     },
     {
+      "id": 4,
       "mineralId": 1,
       "facilityId": 2,
-      "quantity": 4
+      "quantity": 1
     },
     {
+      "id": 5,
       "mineralId": 3,
       "facilityId": 1,
-      "quantity": 20
+      "quantity": 13
     }
   ],
-  "colonyMinerals": []
+  "colonyMinerals": [
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "id": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "id": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "id": 1
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "id": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "id": 2
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "id": 1,
+          "mineralId": 2,
+          "facilityId": 3,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "id": 2,
+          "mineralId": 1,
+          "facilityId": 3,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "id": 3
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "id": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "id": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "id": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 18,
+        "name": "Iron"
+      },
+      "id": 4
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "id": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "id": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "id": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 20,
+        "name": "Molybdenum"
+      },
+      "id": 5
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "id": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "id": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "id": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 18,
+        "name": "Iron"
+      },
+      "id": 6
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "id": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "id": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 4,
+        "name": "Iron"
+      },
+      "id": 7
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "id": 1,
+          "mineralId": 2,
+          "facilityId": 3,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "id": 2,
+          "mineralId": 1,
+          "facilityId": 3,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "id": 2,
+        "mineralId": 1,
+        "facilityId": 3,
+        "quantity": 2,
+        "name": "Iron"
+      },
+      "id": 8
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "id": 1,
+          "mineralId": 2,
+          "facilityId": 3,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "id": 2,
+          "mineralId": 1,
+          "facilityId": 3,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "id": 1,
+        "mineralId": 2,
+        "facilityId": 3,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 9
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "id": 1,
+          "mineralId": 2,
+          "facilityId": 3,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "id": 2,
+          "mineralId": 1,
+          "facilityId": 3,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "id": 2,
+        "mineralId": 1,
+        "facilityId": 3,
+        "quantity": 2,
+        "name": "Iron"
+      },
+      "id": 10
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "id": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "id": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 4,
+        "name": "Iron"
+      },
+      "id": 11
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "id": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "id": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 4,
+        "name": "Iron"
+      },
+      "id": 12
+    },
+    {
+      "governorId": 3,
+      "colonyId": 1,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 20,
+        "name": "Molybdenum"
+      },
+      "id": 13
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 4,
+        "name": "Iron"
+      },
+      "id": 14
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 4,
+        "name": "Iron"
+      },
+      "id": 15
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 18,
+        "name": "Iron"
+      },
+      "id": 16
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 20,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 20,
+        "name": "Molybdenum"
+      },
+      "id": 17
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 4,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 4,
+        "name": "Iron"
+      },
+      "id": 18
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 3,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 3,
+        "name": "Iron"
+      },
+      "id": 19
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 17,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 19,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 19,
+        "name": "Molybdenum"
+      },
+      "id": 20
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Io"
+      },
+      "selectedFacility": 2,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 4,
+          "mineralId": 1,
+          "facilityId": 2,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 4,
+        "mineralId": 1,
+        "facilityId": 2,
+        "quantity": 2,
+        "name": "Iron"
+      },
+      "id": 21
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 17,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 17,
+        "name": "Iron"
+      },
+      "id": 22
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 23
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 24
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 25
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 26
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 1,
+        "quantity": 2,
+        "name": "Iron"
+      },
+      "id": 27
+    },
+    {
+      "governorId": 3,
+      "colonyId": 1,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 28
+    },
+    {
+      "governorId": 3,
+      "colonyId": 1,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 1,
+        "quantity": 16,
+        "name": "Iron"
+      },
+      "id": 29
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 30
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 31
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 32
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 1,
+        "quantity": 2,
+        "name": "Iron"
+      },
+      "id": 33
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 34
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 1,
+        "quantity": 16,
+        "name": "Iron"
+      },
+      "id": 35
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 1,
+        "quantity": 16,
+        "name": "Iron"
+      },
+      "id": 36
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 3,
+        "quantity": 18,
+        "name": "Molybdenum"
+      },
+      "id": 37
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 2,
+        "checked": true,
+        "facilityName": "Titan"
+      },
+      "selectedFacility": 3,
+      "combinedMinerals": [
+        {
+          "facilityId": 3,
+          "mineralId": 2,
+          "quantity": 20,
+          "name": "Chromium"
+        },
+        {
+          "facilityId": 3,
+          "mineralId": 1,
+          "quantity": 2,
+          "name": "Iron"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 3,
+        "mineralId": 2,
+        "quantity": 20,
+        "name": "Chromium"
+      },
+      "id": 38
+    },
+    {
+      "governorId": 3,
+      "colonyId": 1,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 1,
+        "quantity": 16,
+        "name": "Iron"
+      },
+      "id": 39
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 3,
+        "quantity": 18,
+        "name": "Molybdenum"
+      },
+      "id": 40
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityId": 1,
+          "mineralId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityId": 1,
+          "mineralId": 3,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityId": 1,
+        "mineralId": 1,
+        "quantity": 16,
+        "name": "Iron"
+      },
+      "id": 41
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 16,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 16,
+        "name": "Iron"
+      },
+      "id": 42
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 15,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 15,
+        "name": "Iron"
+      },
+      "id": 43
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 1,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 14,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 3,
+        "mineralId": 1,
+        "facilityId": 1,
+        "quantity": 14,
+        "name": "Iron"
+      },
+      "id": 44
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 13,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 18,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 18,
+        "name": "Molybdenum"
+      },
+      "id": 45
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 13,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 17,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 17,
+        "name": "Molybdenum"
+      },
+      "id": 46
+    },
+    {
+      "governorId": 2,
+      "colonyId": 2,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 13,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 16,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 16,
+        "name": "Molybdenum"
+      },
+      "id": 47
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 13,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 15,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 15,
+        "name": "Molybdenum"
+      },
+      "id": 48
+    },
+    {
+      "governorId": 1,
+      "colonyId": 3,
+      "mineralObj": {
+        "id": 3,
+        "checked": true,
+        "facilityName": "Ganymede"
+      },
+      "selectedFacility": 1,
+      "combinedMinerals": [
+        {
+          "facilityMineralId": 3,
+          "mineralId": 1,
+          "facilityId": 1,
+          "quantity": 13,
+          "name": "Iron"
+        },
+        {
+          "facilityMineralId": 5,
+          "mineralId": 3,
+          "facilityId": 1,
+          "quantity": 14,
+          "name": "Molybdenum"
+        }
+      ],
+      "mineralInCart": {
+        "facilityMineralId": 5,
+        "mineralId": 3,
+        "facilityId": 1,
+        "quantity": 14,
+        "name": "Molybdenum"
+      },
+      "id": 49
+    }
+  ]
 }

--- a/scripts/FacilityMinerals.js
+++ b/scripts/FacilityMinerals.js
@@ -1,10 +1,14 @@
 import { SpaceCart } from './SpaceCart.js';
-import { setFacility, setMineral } from './TransientState.js';
+import {
+  setCombinedMinerals,
+  setFacility,
+  setMineral,
+} from './TransientState.js';
 
 // Fetch minerals associated with a specific facility ID
 export const fetchFacilityMinerals = async (facilityId) => {
   let response = await fetch(
-    `http://localhost:8088/facilityMinerals?facilityId=${facilityId}`
+    ` http://localhost:8088/facilityMinerals?facilityId=${facilityId}`
   );
   let facilityMinerals = await response.json();
 
@@ -26,7 +30,7 @@ export const fetchFacilityMinerals = async (facilityId) => {
       if (facilityMineral.mineralId === mineral.id) {
         // Combine the information and add it to the combinedMinerals array
         combinedMinerals.push({
-          id: facilityMineral.id,
+          facilityMineralId: facilityMineral.id,
           mineralId: facilityMineral.mineralId,
           facilityId: facilityMineral.facilityId,
           quantity: facilityMineral.quantity,
@@ -35,7 +39,7 @@ export const fetchFacilityMinerals = async (facilityId) => {
       }
     }
   }
-
+  setCombinedMinerals(combinedMinerals);
   return combinedMinerals;
 };
 
@@ -56,13 +60,12 @@ const handleMineralChoice = async (event) => {
 export const renderFacilityMineralsHTML = (facilityName, minerals) => {
   // Create the heading
   document.addEventListener('change', handleMineralChoice);
-  let mineralsHTML = `<h3>Facility Minerals for ${facilityName}</h3><div>`;
+  let mineralsHTML = ` <h3>Facility Minerals for ${facilityName}</h3><div>`;
 
   // Loop through each mineral and add it to the HTML
   for (let i = 0; i < minerals.length; i++) {
     let mineral = minerals[i];
-    mineralsHTML += `
-            <input data-facility="${facilityName}" type="radio" id="mineral_${mineral.mineralId}" name="facilityMineral" value="${mineral.mineralId}">
+    mineralsHTML += ` <input data-facility="${facilityName}" type="radio" id="mineral_${mineral.mineralId}" name="facilityMineral" value="${mineral.mineralId}">
             <label for="mineral_${mineral.mineralId}">${mineral.quantity} tons of ${mineral.name}</label><br>`;
   }
 

--- a/scripts/SpaceCart.js
+++ b/scripts/SpaceCart.js
@@ -1,10 +1,16 @@
-import { transientState } from './TransientState.js';
+import { purchaseMineral, transientState } from './TransientState.js';
+const handleOrderClick = (event) => {
+  if (event.target.id === 'placeOrder') {
+    purchaseMineral();
+  }
+};
 
 export const SpaceCart = async () => {
   const response = await fetch('http://localhost:8088/minerals');
   const minerals = await response.json();
   const selectedMineral = transientState.mineralObj;
   let html = `<h2>Space Cart</h2>`;
+  document.addEventListener('click', handleOrderClick);
   if (selectedMineral.checked) {
     for (const mineral of minerals) {
       if (mineral.id === selectedMineral.id) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,8 +1,13 @@
 import { Colonies } from './Colonies.js';
 import { GovernorOptions } from './Governors.js';
 import { fetchFacilities, renderFacilitiesDropdown } from './Facilities.js';
-import { handleFacilityDropdownChange } from './FacilityMinerals.js';
+import {
+  fetchFacilityMinerals,
+  handleFacilityDropdownChange,
+  renderFacilityMineralsHTML,
+} from './FacilityMinerals.js';
 import { SpaceCart } from './SpaceCart.js';
+import { transientState } from './TransientState.js';
 
 const render = async () => {
   const governors = await GovernorOptions();
@@ -13,8 +18,7 @@ const render = async () => {
 
   const container = document.getElementById('container');
 
-  container.innerHTML = `
-        <div class="left-container">
+  container.innerHTML = `<div class="left-container">
             <article class="choices">
                 <section class="choices__governor options">
                     <span>Choose a governor</span> 
@@ -48,7 +52,21 @@ const render = async () => {
 
   handleFacilityDropdownChange(facilities); // Pass the facilities to handle the dropdown change
 };
-
-document.addEventListener('DOMContentLoaded', render); // Ensure DOM is loaded
+document.addEventListener('stateChanged', async () => {
+  const facilities = await fetchFacilities();
+  const selectedFacilityId = transientState.selectedFacility;
+  if (selectedFacilityId !== 0) {
+    const facilityMinerals = await fetchFacilityMinerals(selectedFacilityId);
+    const selectedFacility = facilities.find(
+      (facility) => facility.id === selectedFacilityId
+    );
+    const facilityMineralsHTML = renderFacilityMineralsHTML(
+      selectedFacility.name,
+      facilityMinerals
+    );
+    const mineralsSection = document.getElementById('facility_minerals');
+    mineralsSection.innerHTML = facilityMineralsHTML;
+  }
+});
 
 render();


### PR DESCRIPTION
# Description

I updated the transient state module to include a purchaseMineral function. This makes a post request to send the order to colonyMinerals. Then the facilityMinerals array in the database is updated via a put request, subtracting 1 from the quantity. 

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1: Make an order as usual
- [ ] Step 2: Once the order button is clicked, you should see the facility minerals component change and subtract 1 from what was purchased. 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no errors
